### PR TITLE
Launch worker with dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get update -y \
 RUN curl -L https://github.com/concourse/concourse/releases/download/v1.3.1/concourse_linux_amd64 -o /usr/local/bin/concourse \
  && chmod 755 /usr/local/bin/concourse
 
+RUN curl -L https://github.com/Yelp/dumb-init/releases/download/v1.0.2/dumb-init_1.0.2_amd64 -o /usr/local/bin/dumb-init \
+ && chmod +x /usr/local/bin/dumb-init
+
 ENV CONCOURSE=/var/lib/concourse
 ENV CONCOURSE_WEB="$CONCOURSE/web" \
     CONCOURSE_WORK="$CONCOURSE/work" \

--- a/files/concourse-worker.sh
+++ b/files/concourse-worker.sh
@@ -59,6 +59,6 @@ if [ ! -f "$CONCOURSE/worker_key" ]; then
   { ssh-keygen -y -f ~/.ssh/id_ecdsa "$CONCOURSE/worker_key" >> "$CONCOURSE_KEYS/authorized_worker_keys"; } 2>&- || true
 fi
 
-exec concourse worker --work-dir="$CONCOURSE_WORK" \
+/usr/local/bin/dumb-init /usr/local/bin/concourse worker --work-dir="$CONCOURSE_WORK" \
   --tsa-host="${CONCOURSE_TSA_HOST:-0.0.0.0}" --tsa-port "${CONCOURSE_TSA_PORT:-2222}" \
   --tsa-public-key="$CONCOURSE/tsa_key.pub" --tsa-worker-private-key="$CONCOURSE/worker_key"


### PR DESCRIPTION
Launch worker with dumb-init in order to avoid zombie processes[1]

A detailed explaination of the issue: http://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html

[1]http://pastebin.com/zccs39JS
